### PR TITLE
Add extra information on connect for shunned users

### DIFF
--- a/src/user.c
+++ b/src/user.c
@@ -796,6 +796,10 @@ const char *get_connect_extinfo(Client *client)
 	secgroups = get_security_groups(client);
 	if (secgroups)
 		add_nvplist(&list, 100, "security-groups", secgroups);
+	
+	/* tkl shunned */
+	if (IsShunned(client))
+		add_nvplist(&list, 110, "shunned", NULL);
 
 	*retbuf = '\0';
 	for (e = list; e; e = e->next)


### PR DESCRIPTION
When someone is trying to connect and he/she is shunned , it will be displayed on connection server notice, yeah sometimes it might be helpful, why not..

Suggested by armyn https://bugs.unrealircd.org/view.php?id=6106